### PR TITLE
feat(tests): nightly code coverage report

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,5 @@
+version: "1"
+rules:
+  - base: master
+    upstream: spinnaker:master
+    mergeMethod: merge

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,23 @@
+name: test-coverage
+on:
+  schedule:
+    # run nightly
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Send Coverage
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        run: ./gradlew coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Front50
-
+[![Coverage Status](https://coveralls.io/repos/github/armory-io/front50/badge.svg?branch=master)](https://coveralls.io/github/armory-io/front50?branch=master)
 [![Build Status](https://api.travis-ci.org/spinnaker/front50.svg?branch=master)](https://travis-ci.org/spinnaker/front50)
 
 Front50 is the system of record for all Spinnaker metadata, including: application, pipeline and service account configurations.

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,23 @@ plugins {
   id "org.jetbrains.kotlin.plugin.allopen" version "$kotlinVersion" apply false
 }
 
+
+plugins {
+  id 'jacoco'
+  id 'com.github.kt3k.coveralls' version '2.8.4'
+}
+
+allprojects {
+  repositories {
+    jcenter()
+  }
+}
+
+subprojects {
+  apply plugin: 'jacoco'
+  apply plugin: 'com.github.kt3k.coveralls'
+}
+
 subprojects { project ->
   group = "com.netflix.spinnaker.front50"
   apply plugin: 'io.spinnaker.project'
@@ -73,3 +90,40 @@ subprojects { project ->
 }
 
 defaultTasks ':front50-web:run'
+
+def jacocoProjects = subprojects.findAll { it.path != ':front50-bom' }
+task jacocoMerge(type: JacocoMerge) {
+  jacocoProjects.each { subproject ->
+    executionData subproject.tasks.withType(Test)
+  }
+  doFirst {
+    executionData = files(executionData.findAll { it.exists() })
+  }
+}
+
+task jacocoRootReport(type: JacocoReport, group: 'Coverage reports') {
+  description = 'Generates an aggregate report from all subprojects'
+  dependsOn jacocoProjects.test, jacocoMerge
+
+  getSourceDirectories().setFrom(jacocoProjects.sourceSets.main.allSource.srcDirs)
+  getClassDirectories().setFrom(jacocoProjects.sourceSets.main.output)
+
+  executionData jacocoMerge.destinationFile
+
+  reports {
+    html.enabled = true // human readable
+    xml.enabled = true // required by coveralls
+  }
+}
+
+coveralls {
+  sourceDirs = jacocoProjects.sourceSets.main.allSource.srcDirs.flatten()
+  jacocoReportPath = "${buildDir}/reports/jacoco/jacocoRootReport/jacocoRootReport.xml"
+}
+
+tasks.coveralls {
+  group = 'Coverage reports'
+  description = 'Uploads the aggregated coverage report to Coveralls'
+
+  dependsOn jacocoRootReport
+}


### PR DESCRIPTION
We want to start tracking code coverage for OSS repos as well as ours, so this adds a nightly github action that sends a code coverage report to coveralls.